### PR TITLE
fix: set IsFastTrack on submit using ComputeIsFastTrackAsync

### DIFF
--- a/src/SessionPlanner.Infrastructure/Services/TeachingNeedService.cs
+++ b/src/SessionPlanner.Infrastructure/Services/TeachingNeedService.cs
@@ -301,6 +301,7 @@ public class TeachingNeedService : ITeachingNeedService
 
         need.Status = NeedStatus.Submitted;
         need.SubmittedAt = DateTime.UtcNow;
+        need.IsFastTrack = await ComputeIsFastTrackAsync(need);
 
         await _db.SaveChangesAsync();
 


### PR DESCRIPTION
FastTrack was never populated; admin FastTrack badge stayed off for all needs.
