### PR TITLE
feat: intelligent auto-fill for teaching need form fields

### DIFF
--- a/frontend/src/hooks/useAutoFill.ts
+++ b/frontend/src/hooks/useAutoFill.ts
@@ -1,0 +1,117 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useAuth } from '../contexts/AuthContext';
+
+interface AutoFillSuggestion {
+  value: string;
+  reason: string;
+  confidence: number;
+}
+
+interface AutoFillResponse {
+  suggestions: Record<string, AutoFillSuggestion>;
+  source: string;
+}
+
+interface UseAutoFillOptions {
+  sessionId: number;
+  courseId: number;
+  itemType: string;
+  currentValues: Record<string, string>;
+  enabled?: boolean;
+  debounceMs?: number;
+}
+
+export interface FieldSuggestion {
+  value: string;
+  reason: string;
+  confidence: number;
+  fieldName: string;
+}
+
+export function useAutoFill({
+  sessionId,
+  courseId,
+  itemType,
+  currentValues,
+  enabled = true,
+  debounceMs = 500,
+}: UseAutoFillOptions) {
+  const { apiFetch } = useAuth();
+  const [suggestions, setSuggestions] = useState<Record<string, AutoFillSuggestion>>({});
+  const [source, setSource] = useState('');
+  const [loading, setLoading] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastRequestRef = useRef('');
+
+  const fetchSuggestions = useCallback(async (values: Record<string, string>) => {
+    const requestKey = `${sessionId}-${courseId}-${itemType}-${JSON.stringify(values)}`;
+    if (requestKey === lastRequestRef.current) return;
+    lastRequestRef.current = requestKey;
+
+    setLoading(true);
+    try {
+      const result = await apiFetch<AutoFillResponse>('/ai/auto-fill', {
+        method: 'POST',
+        body: JSON.stringify({ sessionId, courseId, itemType, currentValues: values }),
+      });
+      setSuggestions(result.suggestions);
+      setSource(result.source);
+    } catch {
+      setSuggestions({});
+      setSource('');
+    } finally {
+      setLoading(false);
+    }
+  }, [apiFetch, sessionId, courseId, itemType]);
+
+  useEffect(() => {
+    if (!enabled) {
+      setSuggestions({});
+      return;
+    }
+
+    const hasAnyValue = Object.values(currentValues).some((v) => v.trim().length > 0);
+    if (!hasAnyValue) {
+      setSuggestions({});
+      setSource('');
+      return;
+    }
+
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => {
+      void fetchSuggestions(currentValues);
+    }, debounceMs);
+
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [currentValues, enabled, debounceMs, fetchSuggestions]);
+
+  const acceptSuggestion = useCallback((fieldName: string): string | null => {
+    const suggestion = suggestions[fieldName];
+    if (!suggestion) return null;
+    setSuggestions((prev) => {
+      const next = { ...prev };
+      delete next[fieldName];
+      return next;
+    });
+    return suggestion.value;
+  }, [suggestions]);
+
+  const dismissSuggestion = useCallback((fieldName: string) => {
+    setSuggestions((prev) => {
+      const next = { ...prev };
+      delete next[fieldName];
+      return next;
+    });
+  }, []);
+
+  return {
+    suggestions,
+    source,
+    loading,
+    acceptSuggestion,
+    dismissSuggestion,
+    hasSuggestions: Object.keys(suggestions).length > 0,
+  };
+}

--- a/frontend/src/pages/CreateNeedPage.tsx
+++ b/frontend/src/pages/CreateNeedPage.tsx
@@ -28,6 +28,7 @@ import type { SessionResponse } from '../types/sessions';
 import type { OSResponse, LaboratoryLookupResponse, PhysicalServerResponse } from '../types/admin';
 import type { AiSuggestedItem } from '../types/ai';
 import { AiSuggestionsPanel } from '../components/AiSuggestionsPanel';
+import { useAutoFill } from '../hooks/useAutoFill';
 
 const EMPTY_LOOKUPS: NeedItemLookups = {
   softwareNames: [],
@@ -78,6 +79,14 @@ export function CreateNeedPage() {
 
   const currentSchema = useMemo(() => getNeedItemSchema(selectedType, lookups), [selectedType, lookups]);
   const canAddItem = useMemo(() => isNeedItemValid(currentSchema, draftValues), [currentSchema, draftValues]);
+
+  const { suggestions: autoFillSuggestions, acceptSuggestion, dismissSuggestion } = useAutoFill({
+    sessionId: sId,
+    courseId: cId,
+    itemType: selectedType,
+    currentValues: draftValues,
+    enabled: !isEditMode,
+  });
 
   // In edit mode, submit is only possible from Draft or Rejected statuses.
   const canSubmit = !isEditMode || existingStatus === 'Draft' || existingStatus === 'Rejected';
@@ -603,19 +612,52 @@ export function CreateNeedPage() {
                   </label>
 
                   <div className="grid gap-4 md:grid-cols-2">
-                    {currentSchema.fields.map((field) => (
-                      <label key={field.name} className="block md:col-span-1">
-                        <span className="mb-1 block text-xs font-medium text-stone-600">
-                          {field.label}
-                          {field.required ? <span className="ml-0.5 text-rose-500">*</span> : null}
-                        </span>
-                        <FieldRenderer
-                          field={field}
-                          value={draftValues[field.name] ?? ''}
-                          onChange={(name, value) => setDraftValues((prev) => ({ ...prev, [name]: value }))}
-                        />
-                      </label>
-                    ))}
+                    {currentSchema.fields.map((field) => {
+                      const suggestion = autoFillSuggestions[field.name];
+                      return (
+                        <div key={field.name} className="block md:col-span-1">
+                          <label className="block">
+                            <span className="mb-1 block text-xs font-medium text-stone-600">
+                              {field.label}
+                              {field.required ? <span className="ml-0.5 text-rose-500">*</span> : null}
+                            </span>
+                            <FieldRenderer
+                              field={field}
+                              value={draftValues[field.name] ?? ''}
+                              onChange={(name, value) => setDraftValues((prev) => ({ ...prev, [name]: value }))}
+                            />
+                          </label>
+                          {suggestion && !(draftValues[field.name] ?? '').trim() ? (
+                            <div className="mt-1 flex items-center gap-1.5">
+                              <button
+                                type="button"
+                                onClick={() => {
+                                  const val = acceptSuggestion(field.name);
+                                  if (val) setDraftValues((prev) => ({ ...prev, [field.name]: val }));
+                                }}
+                                className="inline-flex items-center gap-1 rounded-lg border border-violet-200 bg-violet-50 px-2 py-0.5 text-[11px] text-violet-700 transition hover:bg-violet-100"
+                              >
+                                <span className="text-violet-400">✦</span>
+                                {field.type === 'select'
+                                  ? (field.options?.find((o) => o.value === suggestion.value)?.label ?? suggestion.value)
+                                  : suggestion.value.length > 40
+                                    ? suggestion.value.slice(0, 40) + '…'
+                                    : suggestion.value}
+                              </button>
+                              <span className="text-[10px] text-stone-400">{suggestion.reason}</span>
+                              <button
+                                type="button"
+                                onClick={() => dismissSuggestion(field.name)}
+                                className="text-[10px] text-stone-300 hover:text-stone-500"
+                                aria-label="Ignorer"
+                              >
+                                ✕
+                              </button>
+                            </div>
+                          ) : null}
+                        </div>
+                      );
+                    })}
                   </div>
 
                   <div className="flex gap-2">

--- a/src/SessionPlanner.Api/Controller/AiController.cs
+++ b/src/SessionPlanner.Api/Controller/AiController.cs
@@ -75,4 +75,25 @@ public class AiController : ControllerBase
 
         return Ok(response);
     }
+
+    [HttpPost("auto-fill")]
+    [SwaggerOperation(
+        Summary = "Get auto-fill suggestions for form fields",
+        Description = "Returns suggested values for empty fields based on course history and software catalog. Does not require OpenAI — works with local data.")]
+    [ProducesResponseType(typeof(AutoFillResponseDto), StatusCodes.Status200OK)]
+    public async Task<IActionResult> AutoFill([FromBody] AutoFillRequestDto request)
+    {
+        var coreRequest = new AutoFillRequest(
+            request.SessionId, request.CourseId, request.ItemType, request.CurrentValues);
+
+        var result = await _aiService.AutoFillFieldsAsync(coreRequest);
+
+        var response = new AutoFillResponseDto(
+            Suggestions: result.Suggestions.ToDictionary(
+                kv => kv.Key,
+                kv => new AutoFillSuggestionDto(kv.Value.Value, kv.Value.Reason, kv.Value.Confidence)),
+            Source: result.Source);
+
+        return Ok(response);
+    }
 }

--- a/src/SessionPlanner.Api/Dtos/Ai/AiSuggestRequest.cs
+++ b/src/SessionPlanner.Api/Dtos/Ai/AiSuggestRequest.cs
@@ -26,3 +26,18 @@ public record AiReviewAnalysisDto(
     IReadOnlyList<AiHistoryComparisonDto> HistoryComparisons);
 
 public record AiHistoryComparisonDto(string SessionTitle, string Similarity);
+
+public record AutoFillRequestDto(
+    int SessionId,
+    int CourseId,
+    string ItemType,
+    Dictionary<string, string> CurrentValues);
+
+public record AutoFillResponseDto(
+    Dictionary<string, AutoFillSuggestionDto> Suggestions,
+    string Source);
+
+public record AutoFillSuggestionDto(
+    string Value,
+    string Reason,
+    float Confidence);

--- a/src/SessionPlanner.Core/Interfaces/IAiSuggestionService.cs
+++ b/src/SessionPlanner.Core/Interfaces/IAiSuggestionService.cs
@@ -4,6 +4,7 @@ public interface IAiSuggestionService
 {
     Task<AiSuggestionsResult> SuggestItemsAsync(int sessionId, int courseId, string? itemType = null);
     Task<AiReviewAnalysis> AnalyzeNeedForReviewAsync(int sessionId, int needId);
+    Task<AutoFillResult> AutoFillFieldsAsync(AutoFillRequest request);
     bool IsConfigured { get; }
 }
 
@@ -29,3 +30,18 @@ public record AiReviewAnalysis(
     IReadOnlyList<AiHistoryComparison> HistoryComparisons);
 
 public record AiHistoryComparison(string SessionTitle, string Similarity);
+
+public record AutoFillRequest(
+    int SessionId,
+    int CourseId,
+    string ItemType,
+    Dictionary<string, string> CurrentValues);
+
+public record AutoFillResult(
+    Dictionary<string, AutoFillSuggestion> Suggestions,
+    string Source);
+
+public record AutoFillSuggestion(
+    string Value,
+    string Reason,
+    float Confidence);

--- a/src/SessionPlanner.Infrastructure/Services/AiSuggestionService.cs
+++ b/src/SessionPlanner.Infrastructure/Services/AiSuggestionService.cs
@@ -480,4 +480,281 @@ public class AiSuggestionService : IAiSuggestionService
     private record HistoryItem(string Type, string? Software, string? Version, string? Os, string? Notes);
     private record CatalogEntry(string Name, string? InstallCommand, List<CatalogVersion> Versions);
     private record CatalogVersion(string Version, string Os);
+
+    // ───── Auto-fill ─────
+
+    public async Task<AutoFillResult> AutoFillFieldsAsync(AutoFillRequest request)
+    {
+        var result = request.ItemType switch
+        {
+            "software" => await AutoFillSoftwareAsync(request),
+            "saas" => await AutoFillSaasAsync(request),
+            "virtual_machine" => await AutoFillVmAsync(request),
+            "physical_server" => await AutoFillServerAsync(request),
+            "configuration" => await AutoFillConfigurationAsync(request),
+            "equipment_loan" => await AutoFillEquipmentAsync(request),
+            _ => new AutoFillResult(new Dictionary<string, AutoFillSuggestion>(), "none")
+        };
+
+        return result;
+    }
+
+    private async Task<AutoFillResult> AutoFillSoftwareAsync(AutoFillRequest req)
+    {
+        var suggestions = new Dictionary<string, AutoFillSuggestion>();
+        var softwareName = req.CurrentValues.GetValueOrDefault("softwareName", "").Trim();
+        var source = "none";
+
+        if (string.IsNullOrEmpty(softwareName)) return new AutoFillResult(suggestions, source);
+
+        // 1. Check history for this course
+        var historyItems = await _db.TeachingNeeds
+            .Where(n => n.CourseId == req.CourseId && n.Status == Core.Enums.NeedStatus.Approved)
+            .OrderByDescending(n => n.ReviewedAt)
+            .SelectMany(n => n.Items)
+            .Include(i => i.Software)
+            .Include(i => i.SoftwareVersion)
+            .Include(i => i.OS)
+            .Where(i => i.ItemType == "software" && i.Software != null
+                        && EF.Functions.Like(i.Software.Name, softwareName))
+            .Take(5)
+            .ToListAsync();
+
+        if (historyItems.Count > 0)
+        {
+            source = "history";
+            var best = historyItems[0];
+
+            if (string.IsNullOrEmpty(req.CurrentValues.GetValueOrDefault("versionNumber")) && best.SoftwareVersion != null)
+                suggestions["versionNumber"] = new AutoFillSuggestion(
+                    best.SoftwareVersion.VersionNumber,
+                    "Dernière version utilisée pour ce cours",
+                    0.9f);
+
+            if (string.IsNullOrEmpty(req.CurrentValues.GetValueOrDefault("osId")) && best.OSId.HasValue)
+                suggestions["osId"] = new AutoFillSuggestion(
+                    best.OSId.Value.ToString(),
+                    "OS utilisé précédemment pour ce cours",
+                    0.9f);
+
+            if (string.IsNullOrEmpty(req.CurrentValues.GetValueOrDefault("installationDetails")) && !string.IsNullOrEmpty(best.Software?.InstallCommand))
+                suggestions["installationDetails"] = new AutoFillSuggestion(
+                    best.Software.InstallCommand,
+                    "Commande du catalogue",
+                    0.85f);
+
+            var historyNotes = historyItems
+                .Where(i => !string.IsNullOrWhiteSpace(i.Notes))
+                .Select(i => i.Notes!)
+                .FirstOrDefault();
+            if (string.IsNullOrEmpty(req.CurrentValues.GetValueOrDefault("notes")) && historyNotes != null)
+                suggestions["notes"] = new AutoFillSuggestion(
+                    historyNotes,
+                    "Notes de la demande précédente",
+                    0.7f);
+
+            return new AutoFillResult(suggestions, source);
+        }
+
+        // 2. Fallback: catalog lookup
+        var catalogSw = await _db.Softwares
+            .Include(s => s.SoftwareVersions).ThenInclude(v => v.OS)
+            .FirstOrDefaultAsync(s => EF.Functions.Like(s.Name, softwareName));
+
+        if (catalogSw != null)
+        {
+            source = "catalog";
+
+            var latestVersion = catalogSw.SoftwareVersions
+                .OrderByDescending(v => v.Id)
+                .FirstOrDefault();
+
+            if (latestVersion != null && string.IsNullOrEmpty(req.CurrentValues.GetValueOrDefault("versionNumber")))
+                suggestions["versionNumber"] = new AutoFillSuggestion(
+                    latestVersion.VersionNumber,
+                    "Dernière version du catalogue",
+                    0.8f);
+
+            if (latestVersion != null && string.IsNullOrEmpty(req.CurrentValues.GetValueOrDefault("osId")))
+                suggestions["osId"] = new AutoFillSuggestion(
+                    latestVersion.OsId.ToString(),
+                    "OS de la dernière version catalogue",
+                    0.75f);
+
+            if (!string.IsNullOrEmpty(catalogSw.InstallCommand) && string.IsNullOrEmpty(req.CurrentValues.GetValueOrDefault("installationDetails")))
+                suggestions["installationDetails"] = new AutoFillSuggestion(
+                    catalogSw.InstallCommand,
+                    "Commande d'installation du catalogue",
+                    0.85f);
+
+            return new AutoFillResult(suggestions, source);
+        }
+
+        return new AutoFillResult(suggestions, source);
+    }
+
+    private async Task<AutoFillResult> AutoFillSaasAsync(AutoFillRequest req)
+    {
+        var suggestions = new Dictionary<string, AutoFillSuggestion>();
+        var name = req.CurrentValues.GetValueOrDefault("name", "").Trim();
+        if (string.IsNullOrEmpty(name)) return new AutoFillResult(suggestions, "none");
+
+        var historyItem = await _db.TeachingNeeds
+            .Where(n => n.CourseId == req.CourseId && n.Status == Core.Enums.NeedStatus.Approved)
+            .OrderByDescending(n => n.ReviewedAt)
+            .SelectMany(n => n.Items)
+            .Where(i => i.ItemType == "saas" && i.DetailsJson != null && i.DetailsJson.Contains(name))
+            .FirstOrDefaultAsync();
+
+        if (historyItem?.DetailsJson != null)
+        {
+            try
+            {
+                using var doc = JsonDocument.Parse(historyItem.DetailsJson);
+                if (doc.RootElement.TryGetProperty("numberOfAccounts", out var acc))
+                {
+                    var val = acc.ToString();
+                    if (!string.IsNullOrEmpty(val) && string.IsNullOrEmpty(req.CurrentValues.GetValueOrDefault("numberOfAccounts")))
+                        suggestions["numberOfAccounts"] = new AutoFillSuggestion(val, "Nombre de comptes de la demande précédente", 0.85f);
+                }
+            }
+            catch { /* ignore parse errors */ }
+        }
+
+        return new AutoFillResult(suggestions, suggestions.Count > 0 ? "history" : "none");
+    }
+
+    private async Task<AutoFillResult> AutoFillVmAsync(AutoFillRequest req)
+    {
+        var suggestions = new Dictionary<string, AutoFillSuggestion>();
+
+        var historyItems = await _db.TeachingNeeds
+            .Where(n => n.CourseId == req.CourseId && n.Status == Core.Enums.NeedStatus.Approved)
+            .OrderByDescending(n => n.ReviewedAt)
+            .SelectMany(n => n.Items)
+            .Where(i => i.ItemType == "virtual_machine" && i.DetailsJson != null)
+            .Take(3)
+            .ToListAsync();
+
+        if (historyItems.Count > 0 && historyItems[0].DetailsJson != null)
+        {
+            try
+            {
+                using var doc = JsonDocument.Parse(historyItems[0].DetailsJson);
+                var root = doc.RootElement;
+                TrySuggestFromJson(root, "cpuCores", req.CurrentValues, suggestions, "CPU des VMs précédentes");
+                TrySuggestFromJson(root, "ramGb", req.CurrentValues, suggestions, "RAM des VMs précédentes");
+                TrySuggestFromJson(root, "storageGb", req.CurrentValues, suggestions, "Stockage des VMs précédentes");
+                TrySuggestFromJson(root, "accessType", req.CurrentValues, suggestions, "Type d'accès précédent");
+                TrySuggestFromJson(root, "quantity", req.CurrentValues, suggestions, "Quantité précédente");
+
+                if (root.TryGetProperty("osId", out var osVal) && string.IsNullOrEmpty(req.CurrentValues.GetValueOrDefault("osId")))
+                    suggestions["osId"] = new AutoFillSuggestion(osVal.ToString(), "OS des VMs précédentes", 0.85f);
+            }
+            catch { /* ignore */ }
+        }
+
+        return new AutoFillResult(suggestions, suggestions.Count > 0 ? "history" : "none");
+    }
+
+    private async Task<AutoFillResult> AutoFillServerAsync(AutoFillRequest req)
+    {
+        var suggestions = new Dictionary<string, AutoFillSuggestion>();
+
+        var historyItems = await _db.TeachingNeeds
+            .Where(n => n.CourseId == req.CourseId && n.Status == Core.Enums.NeedStatus.Approved)
+            .OrderByDescending(n => n.ReviewedAt)
+            .SelectMany(n => n.Items)
+            .Where(i => i.ItemType == "physical_server" && i.DetailsJson != null)
+            .Take(3)
+            .ToListAsync();
+
+        if (historyItems.Count > 0 && historyItems[0].DetailsJson != null)
+        {
+            try
+            {
+                using var doc = JsonDocument.Parse(historyItems[0].DetailsJson);
+                var root = doc.RootElement;
+                TrySuggestFromJson(root, "cpuCores", req.CurrentValues, suggestions, "CPU précédent");
+                TrySuggestFromJson(root, "ramGb", req.CurrentValues, suggestions, "RAM précédente");
+                TrySuggestFromJson(root, "storageGb", req.CurrentValues, suggestions, "Stockage précédent");
+                TrySuggestFromJson(root, "accessType", req.CurrentValues, suggestions, "Type d'accès précédent");
+                if (root.TryGetProperty("osId", out var osVal) && string.IsNullOrEmpty(req.CurrentValues.GetValueOrDefault("osId")))
+                    suggestions["osId"] = new AutoFillSuggestion(osVal.ToString(), "OS précédent", 0.85f);
+            }
+            catch { /* ignore */ }
+        }
+
+        return new AutoFillResult(suggestions, suggestions.Count > 0 ? "history" : "none");
+    }
+
+    private async Task<AutoFillResult> AutoFillConfigurationAsync(AutoFillRequest req)
+    {
+        var suggestions = new Dictionary<string, AutoFillSuggestion>();
+
+        var historyItems = await _db.TeachingNeeds
+            .Where(n => n.CourseId == req.CourseId && n.Status == Core.Enums.NeedStatus.Approved)
+            .OrderByDescending(n => n.ReviewedAt)
+            .SelectMany(n => n.Items)
+            .Where(i => i.ItemType == "configuration" && i.DetailsJson != null)
+            .Take(3)
+            .ToListAsync();
+
+        if (historyItems.Count > 0 && historyItems[0].DetailsJson != null)
+        {
+            try
+            {
+                using var doc = JsonDocument.Parse(historyItems[0].DetailsJson);
+                var root = doc.RootElement;
+                TrySuggestFromJson(root, "osIds", req.CurrentValues, suggestions, "OS des configurations précédentes");
+                TrySuggestFromJson(root, "laboratoryIds", req.CurrentValues, suggestions, "Labos des configurations précédentes");
+                TrySuggestFromJson(root, "notes", req.CurrentValues, suggestions, "Notes de la configuration précédente");
+            }
+            catch { /* ignore */ }
+        }
+
+        return new AutoFillResult(suggestions, suggestions.Count > 0 ? "history" : "none");
+    }
+
+    private async Task<AutoFillResult> AutoFillEquipmentAsync(AutoFillRequest req)
+    {
+        var suggestions = new Dictionary<string, AutoFillSuggestion>();
+        var name = req.CurrentValues.GetValueOrDefault("name", "").Trim();
+        if (string.IsNullOrEmpty(name)) return new AutoFillResult(suggestions, "none");
+
+        var historyItem = await _db.TeachingNeeds
+            .Where(n => n.CourseId == req.CourseId && n.Status == Core.Enums.NeedStatus.Approved)
+            .OrderByDescending(n => n.ReviewedAt)
+            .SelectMany(n => n.Items)
+            .Where(i => i.ItemType == "equipment_loan" && i.DetailsJson != null && i.DetailsJson.Contains(name))
+            .FirstOrDefaultAsync();
+
+        if (historyItem?.DetailsJson != null)
+        {
+            try
+            {
+                using var doc = JsonDocument.Parse(historyItem.DetailsJson);
+                var root = doc.RootElement;
+                TrySuggestFromJson(root, "quantity", req.CurrentValues, suggestions, "Quantité précédente");
+                TrySuggestFromJson(root, "defaultAccessories", req.CurrentValues, suggestions, "Accessoires précédents");
+            }
+            catch { /* ignore */ }
+        }
+
+        return new AutoFillResult(suggestions, suggestions.Count > 0 ? "history" : "none");
+    }
+
+    private static void TrySuggestFromJson(
+        JsonElement root, string fieldName,
+        Dictionary<string, string> currentValues,
+        Dictionary<string, AutoFillSuggestion> suggestions,
+        string reason)
+    {
+        if (root.TryGetProperty(fieldName, out var val))
+        {
+            var strVal = val.ToString();
+            if (!string.IsNullOrEmpty(strVal) && string.IsNullOrEmpty(currentValues.GetValueOrDefault(fieldName)))
+                suggestions[fieldName] = new AutoFillSuggestion(strVal, reason, 0.8f);
+        }
+    }
 }

--- a/tests/SessionPlanner.Tests.Integration/Controllers/AiControllerTests.cs
+++ b/tests/SessionPlanner.Tests.Integration/Controllers/AiControllerTests.cs
@@ -44,5 +44,63 @@ public class AiControllerTests : IClassFixture<CustomWebApplicationFactory>
         response.StatusCode.Should().BeOneOf(HttpStatusCode.OK, HttpStatusCode.ServiceUnavailable);
     }
 
+    [Fact]
+    public async Task AutoFill_ReturnsOkWithSuggestionsStructure()
+    {
+        var response = await _client.PostAsJsonAsync($"{BaseUrl}/auto-fill",
+            new
+            {
+                sessionId = 1,
+                courseId = 1,
+                itemType = "software",
+                currentValues = new Dictionary<string, string> { ["softwareName"] = "Eclipse" }
+            });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<AutoFillResponse>();
+        body.Should().NotBeNull();
+        body!.Source.Should().NotBeNull();
+        body.Suggestions.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task AutoFill_EmptyValues_ReturnsNoSuggestions()
+    {
+        var response = await _client.PostAsJsonAsync($"{BaseUrl}/auto-fill",
+            new
+            {
+                sessionId = 1,
+                courseId = 1,
+                itemType = "software",
+                currentValues = new Dictionary<string, string> { ["softwareName"] = "" }
+            });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<AutoFillResponse>();
+        body.Should().NotBeNull();
+        body!.Source.Should().Be("none");
+        body.Suggestions.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task AutoFill_UnknownItemType_ReturnsEmpty()
+    {
+        var response = await _client.PostAsJsonAsync($"{BaseUrl}/auto-fill",
+            new
+            {
+                sessionId = 1,
+                courseId = 1,
+                itemType = "unknown_type",
+                currentValues = new Dictionary<string, string> { ["foo"] = "bar" }
+            });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<AutoFillResponse>();
+        body.Should().NotBeNull();
+        body!.Source.Should().Be("none");
+    }
+
     private record StatusResponse(bool Available);
+    private record AutoFillSuggestionDto(string Value, string Reason, float Confidence);
+    private record AutoFillResponse(Dictionary<string, AutoFillSuggestionDto> Suggestions, string Source);
 }


### PR DESCRIPTION
Hybrid approach: deterministic history/catalog lookup first (instant, free), with field-level suggestions displayed as clickable badges.

Backend:
- POST /ai/auto-fill endpoint — no OpenAI needed, queries local DB
- Software: matches by name in course history → fills version, OS, install command, notes. Falls back to catalog for latest version.
- SaaS: fills numberOfAccounts from history
- VM/Server: fills cpuCores, ramGb, storageGb, accessType, OS
- Configuration: fills OS list and lab list from history
- Equipment: fills quantity and accessories from history

Frontend:
- useAutoFill hook with 500ms debounce and deduplication
- Violet suggestion badges appear under empty fields when a match is found (e.g. "✦ v1 — Dernière version utilisée pour ce cours")
- Click to accept, ✕ to dismiss
- Integrated into CreateNeedPage for all 6 item types

Tests: 3 new integration tests for auto-fill endpoint
