### PR TITLE
feat: AI rejection correction assistant for teachers

### DIFF
--- a/frontend/src/pages/CreateNeedPage.tsx
+++ b/frontend/src/pages/CreateNeedPage.tsx
@@ -70,6 +70,12 @@ export function CreateNeedPage() {
   const [showHistory, setShowHistory] = useState(false);
   const [cloning, setCloning] = useState(false);
 
+  interface CorrectionStep { action: string; target: string; detail: string; }
+  interface RejectionAssistResponse { explanation: string; steps: CorrectionStep[]; revisedNotes: string | null; }
+  const [rejectionAssist, setRejectionAssist] = useState<RejectionAssistResponse | null>(null);
+  const [rejectionAssistLoading, setRejectionAssistLoading] = useState(false);
+  const [rejectionAssistError, setRejectionAssistError] = useState('');
+
   const [items, setItems] = useState<NeedItemDraft[]>([]);
   const [selectedType, setSelectedType] = useState<TeacherNeedItemType>('software');
   const [draftValues, setDraftValues] = useState<Record<string, string>>(() => {
@@ -214,6 +220,29 @@ export function CreateNeedPage() {
   useEffect(() => {
     void loadData();
   }, [loadData]);
+
+  const fetchRejectionAssist = useCallback(async () => {
+    if (!isEditMode || !nId || existingStatus !== 'Rejected' || !rejectionReason) return;
+    setRejectionAssistLoading(true);
+    setRejectionAssistError('');
+    try {
+      const data = await apiFetch<RejectionAssistResponse>('/ai/rejection-assist', {
+        method: 'POST',
+        body: JSON.stringify({ sessionId: sId, needId: nId }),
+      });
+      setRejectionAssist(data);
+    } catch {
+      setRejectionAssistError('Impossible de charger l\'assistance IA.');
+    } finally {
+      setRejectionAssistLoading(false);
+    }
+  }, [apiFetch, isEditMode, nId, sId, existingStatus, rejectionReason]);
+
+  useEffect(() => {
+    if (existingStatus === 'Rejected' && rejectionReason) {
+      void fetchRejectionAssist();
+    }
+  }, [existingStatus, rejectionReason, fetchRejectionAssist]);
 
   useEffect(() => {
     setDraftValues(getNeedItemSchema(selectedType, lookups).defaultValues);
@@ -543,12 +572,57 @@ export function CreateNeedPage() {
           ) : null}
 
           {isEditMode && existingStatus === 'Rejected' && rejectionReason ? (
-            <div className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-800">
-              <p className="font-semibold">Demande rejetée</p>
-              <p className="mt-1 text-rose-700">Motif indiqué par l&apos;équipe&nbsp;: {rejectionReason}</p>
-              <p className="mt-2 text-xs text-rose-600">
-                Vous pouvez modifier les éléments ci-dessous, puis utiliser «&nbsp;Soumettre&nbsp;» pour renvoyer la demande (brouillon puis soumission).
-              </p>
+            <div className="space-y-3">
+              <div className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-800">
+                <p className="font-semibold">Demande rejetée</p>
+                <p className="mt-1 text-rose-700">Motif indiqué par l&apos;équipe&nbsp;: {rejectionReason}</p>
+                <p className="mt-2 text-xs text-rose-600">
+                  Vous pouvez modifier les éléments ci-dessous, puis utiliser «&nbsp;Soumettre&nbsp;» pour renvoyer la demande (brouillon puis soumission).
+                </p>
+              </div>
+
+              {rejectionAssistLoading ? (
+                <div className="rounded-2xl border border-violet-200 bg-violet-50 px-4 py-3 text-sm text-violet-700 flex items-center gap-2">
+                  <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24"><circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none"/><path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>
+                  Analyse IA en cours…
+                </div>
+              ) : rejectionAssistError ? (
+                <div className="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-700 flex items-center justify-between">
+                  <span>{rejectionAssistError}</span>
+                  <button type="button" onClick={() => void fetchRejectionAssist()} className="text-xs underline hover:no-underline">Réessayer</button>
+                </div>
+              ) : rejectionAssist && rejectionAssist.steps.length > 0 ? (
+                <div className="rounded-2xl border border-violet-200 bg-violet-50 px-4 py-4 text-sm">
+                  <div className="flex items-center gap-2 mb-2">
+                    <span className="inline-flex items-center rounded-full bg-violet-100 px-2 py-0.5 text-xs font-medium text-violet-700">IA</span>
+                    <p className="font-semibold text-violet-800">Assistant de correction</p>
+                  </div>
+                  <p className="text-violet-700 mb-3">{rejectionAssist.explanation}</p>
+                  <ol className="space-y-2">
+                    {rejectionAssist.steps.map((step, i) => (
+                      <li key={i} className="flex items-start gap-2">
+                        <span className="mt-0.5 flex-shrink-0 inline-flex items-center justify-center w-5 h-5 rounded-full bg-violet-200 text-xs font-bold text-violet-800">{i + 1}</span>
+                        <div>
+                          <span className={`inline-block rounded-md px-1.5 py-0.5 text-xs font-medium mr-1 ${
+                            step.action === 'retirer' ? 'bg-rose-100 text-rose-700'
+                              : step.action === 'ajouter' ? 'bg-emerald-100 text-emerald-700'
+                              : step.action === 'vérifier' ? 'bg-amber-100 text-amber-700'
+                              : 'bg-blue-100 text-blue-700'
+                          }`}>{step.action}</span>
+                          <span className="font-medium text-violet-900">{step.target}</span>
+                          <p className="text-violet-700 text-xs mt-0.5">{step.detail}</p>
+                        </div>
+                      </li>
+                    ))}
+                  </ol>
+                  {rejectionAssist.revisedNotes ? (
+                    <div className="mt-3 rounded-lg bg-white/60 border border-violet-100 px-3 py-2">
+                      <p className="text-xs font-medium text-violet-800 mb-1">Notes suggérées :</p>
+                      <p className="text-xs text-violet-700 italic">{rejectionAssist.revisedNotes}</p>
+                    </div>
+                  ) : null}
+                </div>
+              ) : null}
             </div>
           ) : null}
 

--- a/src/SessionPlanner.Api/Controller/AiController.cs
+++ b/src/SessionPlanner.Api/Controller/AiController.cs
@@ -76,6 +76,28 @@ public class AiController : ControllerBase
         return Ok(response);
     }
 
+    [HttpPost("rejection-assist")]
+    [SwaggerOperation(
+        Summary = "Get AI-powered correction guidance for a rejected teaching need",
+        Description = "Analyzes the rejection reason and the need content to suggest concrete correction steps to the teacher.")]
+    [ProducesResponseType(typeof(RejectionAssistResponseDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status503ServiceUnavailable)]
+    public async Task<IActionResult> RejectionAssist([FromBody] RejectionAssistRequestDto request)
+    {
+        if (!_aiService.IsConfigured)
+            return StatusCode(503, new ApiErrorResponse(
+                "AI assistance is not configured. Contact the administrator.", "AI_NOT_CONFIGURED"));
+
+        var result = await _aiService.GetRejectionAssistanceAsync(request.SessionId, request.NeedId);
+
+        var response = new RejectionAssistResponseDto(
+            Explanation: result.Explanation,
+            Steps: result.Steps.Select(s => new CorrectionStepDto(s.Action, s.Target, s.Detail)).ToList(),
+            RevisedNotes: result.RevisedNotes);
+
+        return Ok(response);
+    }
+
     [HttpPost("auto-fill")]
     [SwaggerOperation(
         Summary = "Get auto-fill suggestions for form fields",

--- a/src/SessionPlanner.Api/Dtos/Ai/AiSuggestRequest.cs
+++ b/src/SessionPlanner.Api/Dtos/Ai/AiSuggestRequest.cs
@@ -41,3 +41,15 @@ public record AutoFillSuggestionDto(
     string Value,
     string Reason,
     float Confidence);
+
+public record RejectionAssistRequestDto(int SessionId, int NeedId);
+
+public record RejectionAssistResponseDto(
+    string Explanation,
+    IReadOnlyList<CorrectionStepDto> Steps,
+    string? RevisedNotes);
+
+public record CorrectionStepDto(
+    string Action,
+    string Target,
+    string Detail);

--- a/src/SessionPlanner.Core/Interfaces/IAiSuggestionService.cs
+++ b/src/SessionPlanner.Core/Interfaces/IAiSuggestionService.cs
@@ -5,6 +5,7 @@ public interface IAiSuggestionService
     Task<AiSuggestionsResult> SuggestItemsAsync(int sessionId, int courseId, string? itemType = null);
     Task<AiReviewAnalysis> AnalyzeNeedForReviewAsync(int sessionId, int needId);
     Task<AutoFillResult> AutoFillFieldsAsync(AutoFillRequest request);
+    Task<RejectionAssistResult> GetRejectionAssistanceAsync(int sessionId, int needId);
     bool IsConfigured { get; }
 }
 
@@ -45,3 +46,13 @@ public record AutoFillSuggestion(
     string Value,
     string Reason,
     float Confidence);
+
+public record RejectionAssistResult(
+    string Explanation,
+    IReadOnlyList<RejectionCorrectionStep> Steps,
+    string? RevisedNotes);
+
+public record RejectionCorrectionStep(
+    string Action,
+    string Target,
+    string Detail);

--- a/src/SessionPlanner.Infrastructure/Services/AiSuggestionService.cs
+++ b/src/SessionPlanner.Infrastructure/Services/AiSuggestionService.cs
@@ -5,6 +5,7 @@ using System.Text.Json.Serialization;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using SessionPlanner.Core.Entities;
 using SessionPlanner.Core.Interfaces;
 using SessionPlanner.Infrastructure.Data;
 
@@ -480,6 +481,133 @@ public class AiSuggestionService : IAiSuggestionService
     private record HistoryItem(string Type, string? Software, string? Version, string? Os, string? Notes);
     private record CatalogEntry(string Name, string? InstallCommand, List<CatalogVersion> Versions);
     private record CatalogVersion(string Version, string Os);
+
+    // ───── Rejection assistance ─────
+
+    public async Task<RejectionAssistResult> GetRejectionAssistanceAsync(int sessionId, int needId)
+    {
+        var need = await _db.TeachingNeeds
+            .Include(n => n.Personnel)
+            .Include(n => n.Course)
+            .Include(n => n.Session)
+            .Include(n => n.Items).ThenInclude(i => i.Software)
+            .Include(n => n.Items).ThenInclude(i => i.SoftwareVersion)
+            .Include(n => n.Items).ThenInclude(i => i.OS)
+            .FirstOrDefaultAsync(n => n.Id == needId && n.SessionId == sessionId);
+
+        if (need is null || string.IsNullOrWhiteSpace(need.RejectionReason))
+            return new RejectionAssistResult(
+                "Aucune information de rejet disponible.", [], null);
+
+        var prompt = BuildRejectionAssistPrompt(need);
+
+        try
+        {
+            var json = await CallOpenAiAsync(prompt);
+            return ParseRejectionAssistResponse(json);
+        }
+        catch (OpenAiQuotaException ex)
+        {
+            return new RejectionAssistResult(ex.Message, [], null);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Rejection assist failed for need {NeedId}", needId);
+            return new RejectionAssistResult(
+                "Impossible de générer l'assistance pour le moment.", [], null);
+        }
+    }
+
+    private static string BuildRejectionAssistPrompt(TeachingNeed need)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("Tu es un assistant qui aide un professeur à corriger une demande de besoins technologiques qui a été rejetée par l'administration.");
+        sb.AppendLine("Analyse le motif de rejet et la demande actuelle, puis propose des étapes concrètes de correction.");
+        sb.AppendLine();
+        sb.AppendLine($"Cours: {need.Course?.Code} {need.Course?.Name}");
+        sb.AppendLine($"Session: {need.Session?.Title}");
+        sb.AppendLine();
+        sb.AppendLine($"=== MOTIF DE REJET ===");
+        sb.AppendLine(need.RejectionReason);
+        sb.AppendLine();
+
+        sb.AppendLine("=== CONTENU ACTUEL DE LA DEMANDE ===");
+        if (!string.IsNullOrWhiteSpace(need.Notes))
+            sb.AppendLine($"Notes: {need.Notes}");
+        if (need.ExpectedStudents.HasValue)
+            sb.AppendLine($"Étudiants attendus: {need.ExpectedStudents}");
+        if (!string.IsNullOrWhiteSpace(need.DesiredModifications))
+            sb.AppendLine($"Modifications souhaitées: {need.DesiredModifications}");
+        if (!string.IsNullOrWhiteSpace(need.AdditionalComments))
+            sb.AppendLine($"Commentaires: {need.AdditionalComments}");
+        sb.AppendLine();
+
+        sb.AppendLine("=== ITEMS DE LA DEMANDE ===");
+        foreach (var item in need.Items)
+        {
+            var parts = new List<string> { $"[{item.ItemType}]" };
+            if (item.Software != null) parts.Add(item.Software.Name);
+            if (item.SoftwareVersion != null) parts.Add($"v{item.SoftwareVersion.VersionNumber}");
+            if (item.OS != null) parts.Add($"({item.OS.Name})");
+            if (item.Quantity.HasValue) parts.Add($"Qté: {item.Quantity}");
+            if (!string.IsNullOrWhiteSpace(item.Description)) parts.Add(item.Description);
+            if (!string.IsNullOrWhiteSpace(item.Notes)) parts.Add($"— {item.Notes}");
+            sb.AppendLine($"  {string.Join(" ", parts)}");
+        }
+        if (need.Items.Count == 0)
+            sb.AppendLine("  (aucun item)");
+        sb.AppendLine();
+
+        sb.AppendLine("Réponds en JSON strict (pas de markdown) avec ce format:");
+        sb.AppendLine("""
+{
+  "explanation": "Explication claire en français du problème identifié par l'admin, en 1-2 phrases simples",
+  "steps": [
+    {
+      "action": "modifier" ou "ajouter" ou "retirer" ou "vérifier",
+      "target": "Nom de l'élément concerné (ex: 'IntelliJ', 'Notes de la demande', 'Nombre d'étudiants')",
+      "detail": "Instruction précise de ce qu'il faut faire (ex: 'Changer la version de 2023.1 à 2024.1')"
+    }
+  ],
+  "revisedNotes": "Si les notes de la demande devraient être modifiées, proposer le nouveau texte ici (null sinon)"
+}
+""");
+        sb.AppendLine("Donne entre 1 et 5 étapes de correction concrètes et actionnables. Sois concis et pratique.");
+
+        return sb.ToString();
+    }
+
+    private static RejectionAssistResult ParseRejectionAssistResponse(string json)
+    {
+        var trimmed = json.Trim();
+        if (trimmed.StartsWith("```"))
+        {
+            var firstNewline = trimmed.IndexOf('\n');
+            if (firstNewline > 0) trimmed = trimmed[(firstNewline + 1)..];
+            if (trimmed.EndsWith("```")) trimmed = trimmed[..^3].TrimEnd();
+        }
+
+        using var doc = JsonDocument.Parse(trimmed);
+        var root = doc.RootElement;
+
+        var explanation = root.TryGetProperty("explanation", out var e) ? e.GetString() ?? "" : "";
+
+        var steps = new List<RejectionCorrectionStep>();
+        if (root.TryGetProperty("steps", out var stepsArr))
+        {
+            foreach (var s in stepsArr.EnumerateArray())
+            {
+                var action = s.TryGetProperty("action", out var a) ? a.GetString() ?? "" : "";
+                var target = s.TryGetProperty("target", out var t) ? t.GetString() ?? "" : "";
+                var detail = s.TryGetProperty("detail", out var d) ? d.GetString() ?? "" : "";
+                steps.Add(new RejectionCorrectionStep(action, target, detail));
+            }
+        }
+
+        var revisedNotes = root.TryGetProperty("revisedNotes", out var rn) ? rn.GetString() : null;
+
+        return new RejectionAssistResult(explanation, steps, revisedNotes);
+    }
 
     // ───── Auto-fill ─────
 

--- a/tests/SessionPlanner.Tests.Integration/Controllers/AiControllerTests.cs
+++ b/tests/SessionPlanner.Tests.Integration/Controllers/AiControllerTests.cs
@@ -100,7 +100,47 @@ public class AiControllerTests : IClassFixture<CustomWebApplicationFactory>
         body!.Source.Should().Be("none");
     }
 
+    [Fact]
+    public async Task RejectionAssist_ReturnsSuccessOrServiceUnavailable()
+    {
+        var response = await _client.PostAsJsonAsync($"{BaseUrl}/rejection-assist",
+            new { sessionId = 1, needId = 1 });
+
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.OK, HttpStatusCode.ServiceUnavailable);
+    }
+
+    [Fact]
+    public async Task RejectionAssist_ReturnsCorrectStructure()
+    {
+        var response = await _client.PostAsJsonAsync($"{BaseUrl}/rejection-assist",
+            new { sessionId = 1, needId = 1 });
+
+        if (response.StatusCode == HttpStatusCode.OK)
+        {
+            var body = await response.Content.ReadFromJsonAsync<RejectionAssistResponseDto>();
+            body.Should().NotBeNull();
+            body!.Explanation.Should().NotBeNull();
+            body.Steps.Should().NotBeNull();
+        }
+    }
+
+    [Fact]
+    public async Task RejectionAssist_NonExistentNeed_ReturnsOkWithFallback()
+    {
+        var response = await _client.PostAsJsonAsync($"{BaseUrl}/rejection-assist",
+            new { sessionId = 999, needId = 999 });
+
+        if (response.StatusCode == HttpStatusCode.OK)
+        {
+            var body = await response.Content.ReadFromJsonAsync<RejectionAssistResponseDto>();
+            body.Should().NotBeNull();
+            body!.Steps.Should().BeEmpty();
+        }
+    }
+
     private record StatusResponse(bool Available);
     private record AutoFillSuggestionDto(string Value, string Reason, float Confidence);
     private record AutoFillResponse(Dictionary<string, AutoFillSuggestionDto> Suggestions, string Source);
+    private record CorrectionStepDto(string Action, string Target, string Detail);
+    private record RejectionAssistResponseDto(string Explanation, List<CorrectionStepDto> Steps, string? RevisedNotes);
 }


### PR DESCRIPTION
When a teaching need is rejected, the teacher now sees an AI-powered correction panel that analyzes the rejection reason and suggests concrete steps to fix the submission (modify/add/remove items, update notes, etc.). Loads automatically when editing a rejected need.

- Backend: POST /ai/rejection-assist endpoint with OpenAI integration
- Frontend: violet AI panel below the rejection banner in CreateNeedPage
- Integration tests for the new endpoint

